### PR TITLE
Call 'ProcessMessageResult' on every response from the business logic (issue #6)

### DIFF
--- a/collectors/aws/aws_collector.go
+++ b/collectors/aws/aws_collector.go
@@ -93,9 +93,7 @@ func (collector *SqsCollector) PollForMessages() {
 				collector.ProcessExponentialBackoff(err)
 				for _, msg := range msgs {
 					result := collector.BusinessProcessor(msg.MessageBody) //Business logic
-					if result.Err != nil {
-						collector.ProcessMessageResult(msg, result)
-					}
+					collector.ProcessMessageResult(msg, result)
 				}
 			}
 			go collector.timeout()


### PR DESCRIPTION
Issue #6 On success aws_collector does not Ack the message

**WHY**

All response MUST go thru that logic even when there are no errors, retries, or falal errors since that methods is the one that Acks the messages.  If not AWS messages are kept in flight until they are re-delivered again!
