### PR TITLE
#7 Allow the api port to be selected by the applications

### DIFF
--- a/collectors/base_collector.go
+++ b/collectors/base_collector.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"net/http"
@@ -24,6 +25,7 @@ type BaseCollector struct {
 	RetryIntervalSecs            int64
 	SourceTopic                  string
 	ErrorTopic                   string
+	ApiPort                      int
 	Sleep                        func()
 	Wake                         func()
 	BusinessProcessor            func([]byte) *Result
@@ -46,6 +48,7 @@ func CreateBaseCollector(collectorOptions CollectorOptions) *BaseCollector {
 		RetryIntervalSecs:            collectorOptions.RetryIntervalSecs,
 		SourceTopic:                  collectorOptions.SourceTopic,
 		ErrorTopic:                   collectorOptions.ErrorTopic,
+		ApiPort:                      collectorOptions.ApiPort,
 		BusinessProcessor:            collectorOptions.BusinessProcessor,
 		GetMessages:                  collectorOptions.GetMessages,
 		PublishMessage:               collectorOptions.PublishMessage,
@@ -132,5 +135,9 @@ func (collector *BaseCollector) collectorApi() {
 		})
 	})
 	// Start server
-	e.Logger.Fatal(e.Start(":1323"))
+	apiPort := collector.ApiPort
+	if apiPort == 0 {
+		apiPort = 1323
+	}
+	e.Logger.Fatal(e.Start(fmt.Sprintf(":%d", apiPort)))
 }

--- a/collectors/models.go
+++ b/collectors/models.go
@@ -33,6 +33,7 @@ type CollectorOptions struct {
 	ErrorTopic        string
 	Region            string
 	AccountID         string
+	ApiPort           int
 	BusinessProcessor func([]byte) *Result
 	GetMessages       func() ([]MessageWrapper, error)
 	PublishMessage    func(message *MessageWrapper, delaySeconds int64, errFlag bool) error

--- a/workers/app.go
+++ b/workers/app.go
@@ -25,13 +25,14 @@ func RunAwsCollector() {
 	var err error
 	var options = collectors.CollectorOptions{
 		Region:            "us-east-1",
-		AccountID:         "478989820108",
+		AccountID:         "794373491471",
 		PollingPeriod:     10,
 		MaxPollingPeriod:  60,
 		MaxRetries:        3,
 		RetryIntervalSecs: 60,
-		SourceTopic:       "PAUL_TEST",
-		ErrorTopic:        "PAUL_TILES",
+		SourceTopic:       "input",
+		ErrorTopic:        "error",
+		ApiPort:           8080,
 		BusinessProcessor: businessLogic,
 		GetMessages:       nil,
 		PublishMessage:    nil,
@@ -65,7 +66,7 @@ func RunNsqCollector() {
 }
 
 func main() {
-	RunNsqCollector()
+	RunAwsCollector()
 
 	waitCh := make(chan bool)
 	<-waitCh


### PR DESCRIPTION
Added option to the BaseCollector and the Collector options and updated the RunAwsCollector to use it as port passed in.  If no port was selected then 1323 will be used.

